### PR TITLE
Susa manual name remove, day1

### DIFF
--- a/coderefinery-2025-september/raw/day1-obs.srt
+++ b/coderefinery-2025-september/raw/day1-obs.srt
@@ -10028,7 +10028,7 @@ I'm working on my copy, the
 
 2508
 02:19:35,698 --> 02:19:37,941
-[name]-recipies, not on the main,
+[name]-recipes, not on the main,
 
 2509
 02:19:37,941 --> 02:19:39,022

--- a/coderefinery-2025-september/raw/day1-obs.srt
+++ b/coderefinery-2025-september/raw/day1-obs.srt
@@ -10028,7 +10028,7 @@ I'm working on my copy, the
 
 2508
 02:19:35,698 --> 02:19:37,941
-Subway SAP, not on the main,
+[name]-recipies, not on the main,
 
 2509
 02:19:37,941 --> 02:19:39,022
@@ -10652,7 +10652,7 @@ If you see this button, it says add file.
 
 2664
 03:25:34,046 --> 03:25:35,208
-Do you see this, Eman?
+Do you see this, [name]?
 
 2665
 03:25:35,208 --> 03:25:36,149
@@ -14120,7 +14120,7 @@ Yep.
 
 3531
 04:31:26,296 --> 04:31:27,338
-Iman, I could hear you.
+[name], I could hear you.
 
 3532
 04:31:34,753 --> 04:31:35,755


### PR DESCRIPTION
Manually edited out two instances where a name was still in the subtitles, and one where the repository name was completely off. These are the ones commented in the editlist